### PR TITLE
Added note on Mac network permissions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,15 @@ For sshfs:
 brew install macos-fuse-t/homebrew-cask/fuse-t-sshfs
 ```
 
+Possible Issues
+-----------------
 
+"Operation not permitted"
+-----
+
+From a terminal, if you find that you can not read the contents of a folder under
+the FUSE file system, it may be that access to "Network Volumes" is not enabled.
+See "System Settings" / "Privacy & Security" / "Files and Folders" / 
+<name of your terminal application> / "Network Volumes" and ensure it is 
+enabled.  This is a consequence of fuse-t leveraging the nfs system under the 
+covers.


### PR DESCRIPTION
This cost me more than a day trying to figure out why my FUSE driver wasn't "working".  Wasn't working because MacOS was refusing to call it.  Oddly, `stat` on both files and folders worked, as did `ls` on a file, but I couldn't get directory listings without this.